### PR TITLE
Fixed misleading typo in a config comment

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -56,7 +56,7 @@ play.modules {
   # By default, Play will load any class called Module that is defined
   # in the root package (the "app" directory), or you can define them
   # explicitly below.
-  # If there are any built-in modules that you want to disable, you can list them here.
+  # If there are any built-in modules that you want to enable, you can list them here.
   #enabled += my.application.Module
 
   # If there are any built-in modules that you want to disable, you can list them here.


### PR DESCRIPTION
Changed the word disable to enable on line 59 as it was intended by the original author.