### PR TITLE
Changes due to deprecation to Assets finding in 2.6

### DIFF
--- a/app/controllers/HomeController.scala
+++ b/app/controllers/HomeController.scala
@@ -19,7 +19,7 @@ class HomeController @Inject()(cc: ControllerComponents) (implicit assetsFinder:
    * a path of `/`.
    */
   def index = Action {
-    Ok(views.html.index("Your new application is ready.")(assetsFinder))
+    Ok(views.html.index("Your new application is ready."))
   }
 
 }

--- a/app/controllers/HomeController.scala
+++ b/app/controllers/HomeController.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import javax.inject._
+
 import play.api.mvc._
 
 /**
@@ -8,7 +9,8 @@ import play.api.mvc._
  * application's home page.
  */
 @Singleton
-class HomeController @Inject()(cc: ControllerComponents) extends AbstractController(cc) {
+class HomeController @Inject()(cc: ControllerComponents) (implicit assetsFinder: AssetsFinder)
+  extends AbstractController(cc) {
 
   /**
    * Create an Action to render an HTML page with a welcome message.
@@ -17,7 +19,7 @@ class HomeController @Inject()(cc: ControllerComponents) extends AbstractControl
    * a path of `/`.
    */
   def index = Action {
-    Ok(views.html.index("Your new application is ready."))
+    Ok(views.html.index("Your new application is ready.")(assetsFinder))
   }
 
 }

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -2,7 +2,7 @@
  * This template takes a two arguments, a String containing a
  * message to display and an AssetsFinder to locate static assets.
  *@
-@(message: String)(assetsFinder: AssetsFinder)
+@(message: String)(implicit assetsFinder: AssetsFinder)
 
 @*
  * Call the `main` template with two arguments. The first

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -1,15 +1,15 @@
 @*
- * This template takes a single argument, a String containing a
- * message to display.
+ * This template takes a two arguments, a String containing a
+ * message to display and an AssetsFinder to locate static assets.
  *@
-@(message: String)
+@(message: String)(assetsFinder: AssetsFinder)
 
 @*
  * Call the `main` template with two arguments. The first
  * argument is a `String` with the title of the page, the second
  * argument is an `Html` object containing the body of the page.
  *@
-@main("Welcome to Play") {
+@main("Welcome to Play", assetsFinder) {
 
     @*
      * Get an `Html` object by calling the built-in Play welcome

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -1,19 +1,20 @@
 @*
  * This template is called from the `index` template. This template
  * handles the rendering of the page header and body tags. It takes
- * two arguments, a `String` for the title of the page and an `Html`
- * object to insert into the body of the page.
+ * three arguments, a `String` for the title of the page and an `Html`
+ * object to insert into the body of the page and an `AssetFinder`
+ * to define to reverse route static assets.
  *@
-@(title: String)(content: Html)
+@(title: String, assetsFinder: AssetsFinder)(content: Html)
 
 <!DOCTYPE html>
 <html lang="en">
     <head>
         @* Here's where we render the page title `String`. *@
         <title>@title</title>
-        <link rel="stylesheet" media="screen" href="@routes.Assets.versioned("stylesheets/main.css")">
-        <link rel="shortcut icon" type="image/png" href="@routes.Assets.versioned("images/favicon.png")">
-        <script src="@routes.Assets.versioned("javascripts/hello.js")" type="text/javascript"></script>
+        <link rel="stylesheet" media="screen" href="@assetsFinder.path("stylesheets/main.css")">
+        <link rel="shortcut icon" type="image/png" href="@assetsFinder.path("images/favicon.png")">
+        <script src="@assetsFinder.path("javascripts/hello.js")" type="text/javascript"></script>
     </head>
     <body>
         @* And here's where we render the `Html` object containing

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -347,3 +347,12 @@ db {
   # https://www.playframework.com/documentation/latest/Highlights25#Logging-SQL-statements
   #default.logSql=true
 }
+
+## Static assets
+# Using configuration and assets finder
+# https://www.playframework.com/documentation/latest/AssetsOverview
+# Since
+play.assets {
+  path = "/public"
+  urlPrefix = "/assets"
+}

--- a/conf/routes
+++ b/conf/routes
@@ -10,4 +10,4 @@ GET     /count                      controllers.CountController.count
 GET     /message                    controllers.AsyncController.message
 
 # Map static resources from the /public folder to the /assets URL path
-GET     /assets/*file               controllers.Assets.versioned(path="/public", file: Asset)
+GET     /assets/*file               controllers.Assets.versioned(file)


### PR DESCRIPTION
Small changes to 
`app/controllers/HomeController.scala`
`app/views/index.scala.html`
`app/views/main.scala.html`
` app/views/main.scala.html`
`conf/application.conf`
`conf/routes`
To refrect changes in 2.6.x API (deprecated assets routing), using [AssetsFinder](https://www.playframework.com/documentation/2.6.x/AssetsOverview#Reverse-routing-and-fingerprinting-for-public-assets) instead.